### PR TITLE
Added feature to hide empty suites from report

### DIFF
--- a/lib/protractor-xml2html-reporter.js
+++ b/lib/protractor-xml2html-reporter.js
@@ -154,22 +154,28 @@ var HTMLReport = function() {
           }
       }
 
-      //store suite data
-      suitesData.push({'keyword': 'TestSuite', 'name': suite.name, 'testcases': testCasesNames, 'testcasesresults':testCasesResults, 'testcasestimes': testCasesTimes, 'testcasesmessages': testCasesMessages, 'screenshotsNames':screenshotsNamesOnFailure, 'tests': suite.tests, 'failed': suite.failed, 'errors': suite.errors, 'skipped': suite.skipped, 'passed': suite.passed});
+      // skip empty suites (may be needed when jasmine describe hierarchy is used)
+      if (totalCasesPerSuite > 0) {
+        //store suite data
+        suitesData.push({'keyword': 'TestSuite', 'name': suite.name, 'testcases': testCasesNames, 'testcasesresults':testCasesResults, 'testcasestimes': testCasesTimes, 'testcasesmessages': testCasesMessages, 'screenshotsNames':screenshotsNamesOnFailure, 'tests': suite.tests, 'failed': suite.failed, 'errors': suite.errors, 'skipped': suite.skipped, 'passed': suite.passed});
 
-      //total statistics
-      allSuites.tests += suite.tests;
-      allSuites.failed += suite.failed;
-      allSuites.errors += suite.errors;
-      allSuites.passed += suite.passed;
-      allSuites.skipped += suite.skipped;
-      allSuites.totalTime += Math.ceil(parseFloat(testSuites[i].attr.time));
+        //total statistics
+        allSuites.tests += suite.tests;
+        allSuites.failed += suite.failed;
+        allSuites.errors += suite.errors;
+        allSuites.passed += suite.passed;
+        allSuites.skipped += suite.skipped;
+        allSuites.totalTime += Math.ceil(parseFloat(testSuites[i].attr.time));
 
-      //suites summary
-      if (suite.failed >0) {
-        suitesSummary.failed += 1;
+        //suites summary
+        if (suite.failed >0) {
+          suitesSummary.failed += 1;
+        } else {
+          suitesSummary.passed += 1;
+        }
       } else {
-        suitesSummary.passed += 1;
+        //do not include empty suites in statistics
+        suitesSummary.suites -= 1;
       }
     }
   }


### PR DESCRIPTION
Jasmine allows to create hierarchy of "describe". If "describe" is used as grouping option and contains only common beforeAll / beforeEach / afterEach / afterAll functions (no test cases), it should not be included into report.
