### PR TITLE
New setting 'useHashAsScreenshotName' added 

### DIFF
--- a/lib/protractor-xml2html-reporter.js
+++ b/lib/protractor-xml2html-reporter.js
@@ -17,7 +17,8 @@ var report = {
   time: new Date(),
   screenshotPath: '',
   modifiedSuiteName: false,
-  screenshotsOnlyOnFailure: true
+  screenshotsOnlyOnFailure: true,
+  useHashAsScreenshotName: false
 };
 
 //stores statistics per one suite
@@ -48,6 +49,16 @@ var suitesSummary = {
   failed: 0
 };
 
+String.prototype.hashCode = function() {
+  var hash = 0, i, chr;
+  if (this.length === 0) return hash;
+  for (i = 0; i < this.length; i++) {
+      chr   = this.charCodeAt(i);
+      hash  = ((hash << 5) - hash) + chr;
+      hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+};
 
 /** Function: getPath
  * Returns the path to the given file based on passed directory.
@@ -71,16 +82,16 @@ function readFile(filename) {
 
 //time passed in seconds
 function getTime(time) {
-  var hours = Math.floor(time/3600);
-  var minutes = Math.floor(time % 3600/60);
+  var hours = Math.floor(time / 3600);
+  var minutes = Math.floor(time % 3600 / 60);
   var seconds = (time % 3600) % 60;
 
   return hours + 'h ' + minutes + 'min ' + seconds + 's';
 }
 
-var HTMLReport = function() {
+var HTMLReport = function () {
 
-  var generateSummaries = function(reportXml, report) {
+  var generateSummaries = function (reportXml, report) {
 
     var testStartedOn;
     var testCases;
@@ -93,7 +104,7 @@ var HTMLReport = function() {
     suitesSummary.suites = testSuites.length;
 
 
-    for (var i=0; i<totalSuites; i++) {
+    for (var i = 0; i < totalSuites; i++) {
       //suite statistics
       suite.name = testSuites[i].attr.name;
       suite.tests = parseInt(testSuites[i].attr.tests);
@@ -115,13 +126,13 @@ var HTMLReport = function() {
       var screenshotsNamesOnFailure = [];
       testCases = testSuites[i].childrenNamed('testcase');
       totalCasesPerSuite = testCases.length;
-      for (var j=0; j<totalCasesPerSuite; j++) {
+      for (var j = 0; j < totalCasesPerSuite; j++) {
         //get test cases results
-        if(testCases[j].firstChild == null) {
+        if (testCases[j].firstChild == null) {
           testCasesResults.push('Passed');
-        } else if (testCases[j].firstChild.name == 'failure'){
+        } else if (testCases[j].firstChild.name == 'failure') {
           testCasesResults.push('Failed');
-        } else if (testCases[j].firstChild.name == 'skipped'){
+        } else if (testCases[j].firstChild.name == 'skipped') {
           testCasesResults.push('Skipped');
         }
 
@@ -129,7 +140,7 @@ var HTMLReport = function() {
         testCasesTimes.push(Math.ceil(testCases[j].attr.time));
 
         //get test cases messages
-        if(testCases[j].firstChild == null) {
+        if (testCases[j].firstChild == null) {
           testCasesMessages.push('None');
         } else if (testCases[j].firstChild.name == 'failure') {
           testCasesMessages.push(testCases[j].firstChild.attr.message);
@@ -144,18 +155,24 @@ var HTMLReport = function() {
           if (testCasesResults[j] != 'Failed' && report.screenshotsOnlyOnFailure) {
             screenshotsNamesOnFailure.push('None');
           } else {
+            let fileName = "";
             if (report.modifiedSuiteName) {
-              screenshotsNamesOnFailure.push(report.browser +'-'+ suite.name.substring(suite.name.indexOf(".")+1) + ' ' + testCasesNames[j] + '.png');
-              // screenshotsNamesOnFailure.push(report.browser +'-'+ testSuites[i].attr.name.substring(testSuites[i].attr.name.indexOf(".")+1) + ' ' + testCasesNames[j] + '.png');
+              fileName = report.browser +'-'+ suite.name.substring(suite.name.indexOf(".")+1) + ' ' + testCasesNames[j] + '.png';              
             }
             else {
-              screenshotsNamesOnFailure.push(report.browser +'-'+ suite.name + ' ' + testCasesNames[j] + '.png');
+              fileName = report.browser +'-'+ suite.name + ' ' + testCasesNames[j] + '.png';
             }
+
+            if(report.useHashAsScreenshotName) {             
+              fileName = fileName.hashCode() + ".png";
+            }
+
+            screenshotsNamesOnFailure.push(fileName);
           }
       }
 
       //store suite data
-      suitesData.push({'keyword': 'TestSuite', 'name': suite.name, 'testcases': testCasesNames, 'testcasesresults':testCasesResults, 'testcasestimes': testCasesTimes, 'testcasesmessages': testCasesMessages, 'screenshotsNames':screenshotsNamesOnFailure, 'tests': suite.tests, 'failed': suite.failed, 'errors': suite.errors, 'skipped': suite.skipped, 'passed': suite.passed});
+      suitesData.push({ 'keyword': 'TestSuite', 'name': suite.name, 'testcases': testCasesNames, 'testcasesresults': testCasesResults, 'testcasestimes': testCasesTimes, 'testcasesmessages': testCasesMessages, 'screenshotsNames': screenshotsNamesOnFailure, 'tests': suite.tests, 'failed': suite.failed, 'errors': suite.errors, 'skipped': suite.skipped, 'passed': suite.passed });
 
       //total statistics
       allSuites.tests += suite.tests;
@@ -166,7 +183,7 @@ var HTMLReport = function() {
       allSuites.totalTime += Math.ceil(parseFloat(testSuites[i].attr.time));
 
       //suites summary
-      if (suite.failed >0) {
+      if (suite.failed > 0) {
         suitesSummary.failed += 1;
       } else {
         suitesSummary.passed += 1;
@@ -174,13 +191,14 @@ var HTMLReport = function() {
     }
   }
 
-this.from = function(reportXml, testConfig) {
+  this.from = function (reportXml, testConfig) {
     //set report data based on testConfig
     report.name = testConfig.reportTitle || 'Test Execution Report';
     report.screenshotPath = testConfig.screenshotPath || './screenshots';
     report.browser = testConfig.testBrowser || 'unknown';
     report.browserVersion = testConfig.browserVersion || 'unknownBrowser';
     report.modifiedSuiteName = testConfig.modifiedSuiteName || false;
+    report.useHashAsScreenshotName = testConfig.useHashAsScreenshotName || false;
     if (testConfig.screenshotsOnlyOnFailure == undefined) {
       report.screenshotsOnlyOnFailure = true;
     } else {


### PR DESCRIPTION
New setting 'useHashAsScreenshotName' added to use hash strings as the filename for the screenshots / code format fixed
We had issues with filenames which are too long for windows. So we created the screenshots with the same type of hash-strings as we did in this pull request and made a setting for it to enable the funcitonality for everyone. 