### PR TITLE
Improved the report little bit more with respect to end user view

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ How to use
          capsPromise.then(function (caps) {
             browserName = caps.get('browserName');
             browserVersion = caps.get('version');
+            platform = caps.get('platform');
 
             var HTMLReport = require('protractor-html-reporter');
 
@@ -51,7 +52,8 @@ How to use
                 testBrowser: browserName,
                 browserVersion: browserVersion,
                 modifiedSuiteName: false,
-                screenshotsOnlyOnFailure: true
+                screenshotsOnlyOnFailure: true,
+                testPlatform: platform
             };
             new HTMLReport().from('xmlresults.xml', testConfig);
         });
@@ -126,6 +128,8 @@ The version of the browser.
 It says if suite names were changed at conf.js level. The suite names can be changed using 'jasmine-reporters' module and using modifySuiteName option. If we change the suite names this will also affect the names of screenshots we are looking for. If modifiedSuiteName is set to true the reporter will remove from the suite name the prefix and a dot (e.g. "firefox.") in order to find correct screenshot name. Unfortunately, the reporter will handle such situation only if we change suite name to "browserName.TestSuiteName" form.
 * screenshotsOnlyOnFailure (bool) default: true   
 To display screenshots only in testcases that failed. Default value is "true".
+* testPlatform 
+The name of platform on which the tests were executed.
 
 Credits
 ----------------------------------

--- a/lib/index.tmpl
+++ b/lib/index.tmpl
@@ -26,15 +26,43 @@
     </div>
 
     <div class="container">
-
-    <!--<div class="generated-on"><b>Platform:</b> <%= report.platform %></div>-->
+	
+    <div class="generated-on"><%= report.time %></div>
+	
+    <!--<div class="generated-on"><b>Platform:</b> <%= report.platform %></div>
     <div class="info"><b>Browser:</b> <%= report.browser %> <%= report.browserVersion %></div>
-    <div class="info"><b>Generated on:</b> <%= report.time %></div>
+    <div class="info"><b>Generated on:</b> <%= report.time %></div>-->
 
 
       <div class="row">
         <div class="chart col-lg-6 col-md-6" id="piechart_testsuites"></div>
         <div class="chart col-lg-6 col-md-6" id="piechart_testcases"></div>
+      </div>
+	  
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h4 class="panel-title">
+            <a data-toggle="collapse" href="#logOutput">
+              <i class="glyphicon glyphicon-chevron-right"></i>
+              <i class="glyphicon glyphicon-chevron-down"></i>
+              <b>Environment</b>
+            </a>
+          </h4>
+        </div>
+        <div id="logOutput" class="panel-collapse collapse">
+          <div class="panel-body">
+            <div class="row">
+              <div class="clearfix metadata col-xs-12 col-sm-6 col-md-6 col-lg-6">
+                  <div class="pull-left">
+                    <strong> Browser: </strong><%= report.browser %> <%= report.browserVersion %>
+                  </div>
+                  <div class="pull-right">
+                    <strong> Platform: </strong><%= report.platform %>
+                  </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <%= testsuites %>

--- a/lib/protractor-xml2html-reporter.js
+++ b/lib/protractor-xml2html-reporter.js
@@ -186,7 +186,7 @@ this.from = function(reportXml, testConfig) {
     } else {
       report.screenshotsOnlyOnFailure = testConfig.screenshotsOnlyOnFailure;
     }
-    // report.platform = testConfig.platform;
+    report.platform = testConfig.testPlatform || 'unknown';
 
     //generate statistics
     var testDetails = generateSummaries(reportXml, report);

--- a/lib/style.css
+++ b/lib/style.css
@@ -166,3 +166,8 @@ th {
 .col-lg-11 {
     width: 100%;
 }
+
+.generated-on {
+    text-align: right;
+    padding-bottom: 10px;
+}

--- a/lib/style.css
+++ b/lib/style.css
@@ -162,3 +162,7 @@ th {
 .footer-link:hover {
     color: darkgray;
 }
+
+.col-lg-11 {
+    width: 100%;
+}


### PR DESCRIPTION
Hi,

First of all thanks for the repository for nice protractor reporting.

While working on Protractor reporting I also feel to do something like whatever you did similar to cucumber-html-report but before I start found your repo. 

While using your repository, I did few changes with respect to end-user view into the HTML as well as into the reporting. Please review my changes and accept the pull request.

Thanks in advance,
Abhishek Yadav

**Changes which I made:**
-  Added **"100%" width** for TestSuite rows in CSS

-  Added current execution **platform** in report

`report.platform = testConfig.testPlatform || 'unknown';`

-  Added a new row for **Environment**, please suggest other heading if this not looks generic
-  Added condition statement for Failed and Skipped, it will not be displayed if the count is 0.

```
<% if (allSuites.failed != 0) { %><span class="label label-danger" title=<%= allSuites.reportAs %>>Failed: <%= allSuites.failed %></span> <% } %>
<% if (allSuites.skipped != 0) { %><span class="label label-warning" title=<%= allSuites.reportAs %>>Skipped: <%= allSuites.skipped %></span> <% } %>
```

-  Updated read me accordingly.

For the report please visit: [https://screenshots.firefox.com/bX9zdeCrv11XjqBJ/null](https://screenshots.firefox.com/bX9zdeCrv11XjqBJ/null)

Link is valid for 14 days from today

