### PR TITLE
Feature: fileNamePrefix setting for HTML report file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ How to use
 
             var HTMLReport = require('protractor-html-reporter');
 
-			testConfig = {
+                testConfig = {
                 reportTitle: 'Test Execution Report',
                 outputPath: './',
                 screenshotPath: './screenshots',
                 testBrowser: browserName,
                 browserVersion: browserVersion,
+                fileNamePrefix: '',
                 modifiedSuiteName: false,
                 screenshotsOnlyOnFailure: true
             };

--- a/lib/protractor-xml2html-reporter.js
+++ b/lib/protractor-xml2html-reporter.js
@@ -13,6 +13,7 @@ var report = {
   name: '',
   browser: '',
   browserVersion: '',
+  fileNamePrefix: '',
   platform: '',
   time: new Date(),
   screenshotPath: '',
@@ -180,6 +181,7 @@ this.from = function(reportXml, testConfig) {
     report.screenshotPath = testConfig.screenshotPath || './screenshots';
     report.browser = testConfig.testBrowser || 'unknown';
     report.browserVersion = testConfig.browserVersion || 'unknownBrowser';
+    report.fileNamePrefix = testConfig.fileNamePrefix || '';
     report.modifiedSuiteName = testConfig.modifiedSuiteName || false;
     if (testConfig.screenshotsOnlyOnFailure == undefined) {
       report.screenshotsOnlyOnFailure = true;
@@ -196,7 +198,7 @@ this.from = function(reportXml, testConfig) {
     report.time = report.time.toLocaleString();
 
     //write to html file
-    var testOutputPath = getPath('/' + report.browser + '-test-report.html', testConfig['outputPath'] || './');
+    var testOutputPath = getPath('/' + report.fileNamePrefix + '-' + report.browser + '-test-report.html', testConfig['outputPath'] || './');
     fileSystem.writeFileSync(
       testOutputPath,
       _.template(readFile(getPath('index.tmpl')))({


### PR DESCRIPTION
Now it is possible to set fileNamePrefix: 'examplePrefix' in testConfig{}, e.g.

let testConfig = {
           reportTitle: 'Test Execution Report',
           outputPath: './testreports',
           fileNamePrefix: currentDate,
           screenshotPath: './screenshots',
           testBrowser: browserName,
           browserVersion: browserVersion,
           modifiedSuiteName: false,
           screenshotsOnlyOnFailure: true
       }; 

As requested in #12 